### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/rodrigofukugauti2501/7bf417e8-3e13-45f3-a2c2-a94e517201d9/568af3d9-99e1-4ac0-a40e-b80b97033731/_apis/work/boardbadge/c265fd9f-de46-4736-98d0-2cc813ace8b9)](https://dev.azure.com/rodrigofukugauti2501/7bf417e8-3e13-45f3-a2c2-a94e517201d9/_boards/board/t/568af3d9-99e1-4ac0-a40e-b80b97033731/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rodrigofukugauti2501/7bf417e8-3e13-45f3-a2c2-a94e517201d9/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.